### PR TITLE
Use Vagrant for Local Development Vms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
-# Whitelist the composer directory in vendor.  If we don't do this, problems
-# ensue due to Laravel's structure.
-
-# Ignore these files and directories.
+.vagrant
 
 app/config/*
+
 !vendor
 vendor/*
 !vendor/composer
+
 composer.phar
 composer.lock
+
 .DS_Store
 *.swp

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    config.vm.box = "ubuntu/trusty64"
+    config.vm.network "private_network", ip: "192.168.34.34"
+
+    # Give the vagrant share more memory.  If we don't do this, it runs out of
+    # RAM in the MySQL provisioning stage.
+    config.vm.provider "virtualbox" do |v|
+        v.memory = 1024
+    end
+
+    # Chef provisioning using vagrant-berkshelf plugin and chef_solo
+    config.berkshelf.enabled = true
+    config.berkshelf.berksfile_path = "cookbooks/development/Berksfile"
+
+    config.vm.provision "chef_solo" do |chef|
+      chef.add_recipe "development::default"
+    end
+
+    # There are issues with vagrant shares and symlinks.
+    #
+    # http://stackoverflow.com/questions/24200333/symbolic-links-and-synced-folders-in-vagrant
+    #
+    # A simple work around, since this is just a local development environment,
+    # is to share the whole folder right where we need it.
+    #
+    config.vm.synced_folder ".", "/srv/www/foresttofarm.org/", group:  'www-data', owner: 'www-data'
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,10 +13,10 @@ Vagrant.configure("2") do |config|
 
     # Chef provisioning using vagrant-berkshelf plugin and chef_solo
     config.berkshelf.enabled = true
-    config.berkshelf.berksfile_path = "cookbooks/development/Berksfile"
+    config.berkshelf.berksfile_path = "cookbooks/foresttofarm-development/Berksfile"
 
     config.vm.provision "chef_solo" do |chef|
-      chef.add_recipe "development::default"
+      chef.add_recipe "foresttofarm-development::default"
     end
 
     # There are issues with vagrant shares and symlinks.

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/.kitchen.yml
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/.kitchen.yml
@@ -1,0 +1,21 @@
+---
+driver:
+  name: vagrant
+  synced_folders:
+    - [<%= File.join(ENV['PWD'], '..', '..')%>, '/tmp/repo-data']
+
+provisioner:
+  name: chef_zero
+  encrypted_data_bag_secret_key_path: 'secrets/fakey-mcfakerton'
+  data_bags_path: './data_bags'
+
+platforms:
+  - name: ubuntu-16.04
+  - name: centos-7.2
+
+suites:
+  - name: default
+    run_list:
+      - recipe[delivery_build::default]
+      - recipe[test]
+    attributes:

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/Berksfile
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/Berksfile
@@ -1,0 +1,18 @@
+source 'https://supermarket.chef.io'
+
+metadata
+
+cookbook 'delivery-truck',
+  git: 'https://github.com/chef-cookbooks/delivery-truck.git',
+  branch: 'master'
+
+# This is so we know where to get delivery-truck's dependency
+cookbook 'delivery-sugar',
+  git: 'https://github.com/chef-cookbooks/delivery-sugar.git',
+  branch: 'master'
+
+group :delivery do
+  cookbook 'delivery_build', git: 'https://github.com/chef-cookbooks/delivery_build'
+  cookbook 'delivery-base', git: 'https://github.com/chef-cookbooks/delivery-base'
+  cookbook 'test', path: './test/fixtures/cookbooks/test'
+end

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/LICENSE
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/LICENSE
@@ -1,0 +1,3 @@
+Copyright 2016 The Authors
+
+All rights reserved, do not redistribute.

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/README.md
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/README.md
@@ -1,0 +1,146 @@
+# build_cookbook
+
+A build cookbook for running the parent project through Chef Delivery
+
+This build cookbook should be customized to suit the needs of the parent project. Using this cookbook can be done outside of Chef Delivery, too. If the parent project is a Chef cookbook, we've detected that and "wrapped" [delivery-truck](https://github.com/chef-cookbooks/delivery-truck). That means it is a dependency, and each of its pipeline phase recipes is included in the appropriate phase recipes in this cookbook. If the parent project is not a cookbook, it's left as an exercise to the reader to customize the recipes as needed for each phase in the pipeline.
+
+## .delivery/config.json
+
+In the parent directory to this build_cookbook, the `config.json` can be modified as necessary. For example, phases can be skipped, publishing information can be added, and so on. Refer to customer support or the Chef Delivery documentation for assistance on what options are available for this configuration.
+
+## Test Kitchen - Local Verify Testing
+
+This cookbook also has a `.kitchen.yml` which can be used to create local build nodes with Test Kitchen to perform the verification phases, `unit`, `syntax`, and `lint`. When running `kitchen converge`, the instances will be set up like Chef Delivery "build nodes" with the [delivery_build cookbook](https://github.com/chef-cookbooks/delivery_build). The reason for this is to make sure that the same exact kind of nodes are used by this build cookbook are run on the local workstation as would run Delivery. It will run `delivery job verify PHASE` for the parent project.
+
+Modify the `.kitchen.yml` if necessary to change the platforms or other configuration to run the verify phases. After making changes in the parent project, `cd` into this directory (`.delivery/build_cookbook`), and run:
+
+```
+kitchen test
+```
+
+## Recipes
+
+Each of the recipes in this build_cookbook are run in the named phase during the Chef Delivery pipeline. The `unit`, `syntax`, and `lint` recipes are additionally run when using Test Kitchen for local testing as noted in the above section.
+
+## Making Changes - Cookbook Example
+
+When making changes in the parent project (that which lives in `../..` from this directory), or in the recipes in this build cookbook, there is a bespoke workflow for Chef Delivery. As an example, we'll discuss a Chef Cookbook as the parent.
+
+First, create a new branch for the changes.
+
+```
+git checkout -b testing-build-cookbook
+```
+
+Next, increment the version in the metadata.rb. This should be in the _parent_, not in this, the build_cookbook. If this is not done, the verify phase will fail.
+
+```
+% git diff
+<SNIP>
+-version '0.1.0'
++version '0.1.1'
+```
+
+The change we'll use for an example is to install the `zsh` package. Write a failing ChefSpec in the cookbook project's `spec/unit/recipes/default_spec.rb`.
+
+```ruby
+require 'spec_helper'
+
+describe 'godzilla::default' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'installs zsh' do
+      expect(chef_run).to install_package('zsh')
+    end
+  end
+end
+```
+
+Commit the local changes as work in progress. The `delivery job` expects to use a clean git repository.
+
+```
+git add ../..
+git commit -m 'WIP: Testing changes'
+```
+
+From _this_ directory (`.delivery/build_cookbook`, relative to the parent cookbook project), run
+
+```
+cd .delivery/build_cookbook
+kitchen converge
+```
+
+This will take some time at first, because the VMs need to be created, Chef installed, the Delivery CLI installed, etc. Later runs will be faster until they are destroyed. It will also fail on the first VM, as expected, because we wrote the test first. Now edit the parent cookbook project's default recipe to install `zsh`.
+
+```
+cd ../../
+$EDITOR/recipes/default.rb
+```
+
+It should look like this:
+
+```
+package 'zsh'
+```
+
+Create another commit.
+
+```
+git add .
+git commit -m 'WIP: Install zsh in default recipe'
+```
+
+Now rerun kitchen from the build_cookbook.
+
+```
+cd .delivery/build_cookbook
+kitchen converge
+```
+
+This will take awhile because it will now pass on the first VM, and then create the second VM. We should have warned you this was a good time for a coffee break.
+
+```
+Recipe: test::default
+
+- execute HOME=/home/vagrant delivery job verify unit --server localhost --ent test --org kitchen
+  * execute[HOME=/home/vagrant delivery job verify lint --server localhost --ent test --org kitchen] action run
+    - execute HOME=/home/vagrant delivery job verify lint --server localhost --ent test --org kitchen
+
+    - execute HOME=/home/vagrant delivery job verify syntax --server localhost --ent test --org kitchen
+
+Running handlers:
+Running handlers complete
+Chef Client finished, 3/32 resources updated in 54.665445968 seconds
+Finished converging <default-centos-71> (1m26.83s).
+```
+
+Victory is ours! Our verify phase passed on the build nodes.
+
+We are ready to run this through our Delivery pipeline. Simply run `delivery review` on the local system from the parent project, and it will open a browser window up to the change we just added.
+
+```
+cd ../..
+delivery review
+```
+
+## FAQ
+
+### Why don't I just run rspec and foodcritic/rubocop on my local system?
+
+An objection to the Test Kitchen approach is that it is much faster to run the unit, lint, and syntax commands for the project on the local system. That is totally true, and also totally valid. Do that for the really fast feedback loop. However, the dance we do with Test Kitchen brings a much higher degree of confidence in the changes we're making, that everything will run on the build nodes in Chef Delivery. We strongly encourage this approach before actually pushing the changes to Delivery.
+
+### Why do I have to make a commit every time?
+
+When running `delivery job`, it expects to merge the commit for the changeset against the clean master branch. If we don't save our progress by making a commit, our local changes aren't run through `delivery job` in the Test Kitchen build instances. We can always perform an interactive rebase, and modify the original changeset message in Delivery with `delivery review --edit`. The latter won't modify the git commits, only the changeset in Delivery.
+
+### What do I do next?
+
+Make changes in the cookbook project as required for organizational goals and needs. Modify the `build_cookbook` as necessary for the pipeline phases that the cookbook should go through.
+
+### What if I get stuck?
+
+Contact Chef Support, or your Chef Customer Success team and they will help you get unstuck.

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/chefignore
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/chefignore
@@ -1,0 +1,102 @@
+# Put files/directories that should be ignored in this file when uploading
+# to a chef-server or supermarket.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+examples/*
+Guardfile
+Procfile
+.kitchen*
+.rubocop.yml
+spec/*
+Rakefile
+.travis.yml
+.foodcritic
+.codeclimate.yml
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING*
+CHANGELOG*
+TESTING*
+MAINTAINERS.toml
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/data_bags/keys/delivery_builder_keys.json
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/data_bags/keys/delivery_builder_keys.json
@@ -1,0 +1,1 @@
+{"id": "delivery_builder_keys"}

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/metadata.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/metadata.rb
@@ -1,0 +1,7 @@
+name 'build_cookbook'
+maintainer 'The Authors'
+maintainer_email 'you@example.com'
+license 'all_rights'
+version '0.1.0'
+
+depends 'delivery-truck'

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/default.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/default.rb
@@ -1,0 +1,6 @@
+#
+# Cookbook Name:: build_cookbook
+# Recipe:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+include_recipe 'delivery-truck::default'

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/deploy.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/deploy.rb
@@ -1,0 +1,6 @@
+#
+# Cookbook Name:: build_cookbook
+# Recipe:: deploy
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+include_recipe 'delivery-truck::deploy'

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/functional.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/functional.rb
@@ -1,0 +1,6 @@
+#
+# Cookbook Name:: build_cookbook
+# Recipe:: functional
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+include_recipe 'delivery-truck::functional'

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/lint.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/lint.rb
@@ -1,0 +1,6 @@
+#
+# Cookbook Name:: build_cookbook
+# Recipe:: lint
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+include_recipe 'delivery-truck::lint'

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/provision.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/provision.rb
@@ -1,0 +1,6 @@
+#
+# Cookbook Name:: build_cookbook
+# Recipe:: provision
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+include_recipe 'delivery-truck::provision'

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/publish.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/publish.rb
@@ -1,0 +1,6 @@
+#
+# Cookbook Name:: build_cookbook
+# Recipe:: publish
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+include_recipe 'delivery-truck::publish'

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/quality.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/quality.rb
@@ -1,0 +1,6 @@
+#
+# Cookbook Name:: build_cookbook
+# Recipe:: quality
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+include_recipe 'delivery-truck::quality'

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/security.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/security.rb
@@ -1,0 +1,6 @@
+#
+# Cookbook Name:: build_cookbook
+# Recipe:: security
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+include_recipe 'delivery-truck::security'

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/smoke.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/smoke.rb
@@ -1,0 +1,6 @@
+#
+# Cookbook Name:: build_cookbook
+# Recipe:: smoke
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+include_recipe 'delivery-truck::smoke'

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/syntax.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/syntax.rb
@@ -1,0 +1,6 @@
+#
+# Cookbook Name:: build_cookbook
+# Recipe:: syntax
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+include_recipe 'delivery-truck::syntax'

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/unit.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/recipes/unit.rb
@@ -1,0 +1,6 @@
+#
+# Cookbook Name:: build_cookbook
+# Recipe:: unit
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+include_recipe 'delivery-truck::unit'

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/test/fixtures/cookbooks/test/metadata.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/test/fixtures/cookbooks/test/metadata.rb
@@ -1,0 +1,2 @@
+name 'test'
+version '0.1.0'

--- a/cookbooks/foresttofarm-development/.delivery/build_cookbook/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/cookbooks/foresttofarm-development/.delivery/build_cookbook/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,0 +1,7 @@
+%w(unit lint syntax).each do |phase|
+  # TODO: This works on Linux/Unix. Not Windows.
+  execute "HOME=/home/vagrant delivery job verify #{phase} --server localhost --ent test --org kitchen" do
+    cwd '/tmp/repo-data'
+    user 'vagrant'
+  end
+end

--- a/cookbooks/foresttofarm-development/.delivery/config.json
+++ b/cookbooks/foresttofarm-development/.delivery/config.json
@@ -1,0 +1,10 @@
+{
+  "version": "2",
+  "build_cookbook": {
+    "name": "build_cookbook",
+    "path": ".delivery/build_cookbook"
+  },
+  "skip_phases": [],
+  "build_nodes": {},
+  "dependencies": []
+}

--- a/cookbooks/foresttofarm-development/.delivery/project.toml
+++ b/cookbooks/foresttofarm-development/.delivery/project.toml
@@ -1,0 +1,21 @@
+# Delivery Prototype for Local Phases Execution
+#
+# The purpose of this file is to prototype a new way to execute
+# phases locally on your workstation. The delivery-cli will read
+# this file and execute the command(s) that are configured for
+# each phase. You can customize them by just modifying the phase
+# key on this file.
+#
+# By default these phases are configured for Cookbook Workflow only
+#
+# As this is still a prototype we are not modifying the current
+# config.json file and it will continue working as usual. 
+
+[local_phases]
+unit = "rspec spec/"
+lint = "cookstyle"
+syntax = "foodcritic . --exclude spec -f any"
+provision = "chef exec kitchen create"
+deploy = "chef exec kitchen converge"
+smoke = "chef exec kitchen verify"
+cleanup = "chef exec kitchen destroy"

--- a/cookbooks/foresttofarm-development/.gitignore
+++ b/cookbooks/foresttofarm-development/.gitignore
@@ -1,0 +1,16 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/cookbooks/foresttofarm-development/.kitchen.yml
+++ b/cookbooks/foresttofarm-development/.kitchen.yml
@@ -1,0 +1,17 @@
+---
+driver:
+  name: vagrant
+  network: 
+      - ["private_network", {ip: 192.168.34.34}]
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-14.04
+
+suites:
+  - name: default
+    run_list:
+      - recipe[development::default]
+    attributes:

--- a/cookbooks/foresttofarm-development/Berksfile
+++ b/cookbooks/foresttofarm-development/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/cookbooks/foresttofarm-development/README.md
+++ b/cookbooks/foresttofarm-development/README.md
@@ -1,0 +1,20 @@
+# foresttofarm-development
+
+This cookbook performs provisioning for a vagrant based development server to
+enable local development on Forest to Farm.
+
+The ``default.rb`` recipe acts primarily as a runlist including dependencies in
+the necessary order, followed by the recipes in this cookbook in the proper
+order. 
+
+The ``php.rb`` recipe performs additional configuration for the PHP server.
+
+The ``web.rb`` recipe configures the apache2 virtual host.
+
+The ``database.rb`` recipe installs the mysql client and server, configures
+them, imports the database schema, and then runs a script to import the data
+from a csv file into the database.
+
+
+
+

--- a/cookbooks/foresttofarm-development/attributes/default.rb
+++ b/cookbooks/foresttofarm-development/attributes/default.rb
@@ -1,0 +1,55 @@
+
+#######################################
+#   General Configuration
+#######################################
+
+# The root directory for Forest to Farm's source, a vagrant share directory.
+default['foresttofarm.org']['source_directory'] = '/srv/www/foresttofarm.org'
+
+#######################################
+#   PHP Configuration
+#######################################
+
+default['foresttofarm.org']['php']['config_file_path'] = '/etc/php5/apache2/php.ini'
+
+# This is necessary to fix an issue in the php-mcrypt cookbook.  For some
+# reason it didn't seem to gain access to this value from the php cookbook. I'm
+# not sure if it was getting overriden somewhere or if recipes just don't
+# necessarily gain access to each other's attributes, but for whatever reason,
+# this fixed it.
+override['php']['ext_conf_dir'] = '/etc/php5/mods-available'
+
+
+#######################################
+#   Apache2 Configuration 
+#######################################
+
+default['foresttofarm.org']['site_name'] = 'foresttofarm.org'
+default['foresttofarm.org']['server_name'] = 'foresttofarm.local'
+
+# Note: server_aliases must be an array
+default['foresttofarm.org']['server_aliases'] = ['www.foresttofarm.local'] 
+default['foresttofarm.org']['document_root'] = '/srv/www/foresttofarm.org/public/'
+
+
+#######################################
+#   MySQL Database Configuration 
+#######################################
+
+# This code isn't intended for anything other than local development on a
+# vagrant box connected only to a local private network.  It should never, ever
+# be run on production servers, and if it is, it will likely break many things.
+# Thus, we aren't going to go to any great lengths to choose secure passwords
+# or encrypt them in data bags or anything like that.
+default['foresttofarm.org']['database']['root_password'] = 'password'
+default['foresttofarm.org']['database']['host'] = '127.0.0.1'
+
+default['foresttofarm.org']['database']['name'] = 'local_foresttofarm'
+
+default['foresttofarm.org']['database']['username'] = 'developer'
+default['foresttofarm.org']['database']['password'] = 'developing'
+
+default['foresttofarm.org']['database']['data_directory'] = '/srv/www/foresttofarm.org/data/'
+default['foresttofarm.org']['database']['schema_file'] = 'schema.sql'
+
+default['foresttofarm.org']['database']['data_file'] = 'data.csv'

--- a/cookbooks/foresttofarm-development/chefignore
+++ b/cookbooks/foresttofarm-development/chefignore
@@ -1,0 +1,102 @@
+# Put files/directories that should be ignored in this file when uploading
+# to a chef-server or supermarket.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+examples/*
+Guardfile
+Procfile
+.kitchen*
+.rubocop.yml
+spec/*
+Rakefile
+.travis.yml
+.foodcritic
+.codeclimate.yml
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING*
+CHANGELOG*
+TESTING*
+MAINTAINERS.toml
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile

--- a/cookbooks/foresttofarm-development/metadata.rb
+++ b/cookbooks/foresttofarm-development/metadata.rb
@@ -1,0 +1,16 @@
+name 'foresttofarm-development'
+maintainer 'Daniel Bingham'
+maintainer_email 'dbingham@theroadgoeson.com'
+license 'all_rights'
+description 'Installs/Configures foresttofarm-development'
+long_description 'Installs/Configures foresttofarm-development'
+version '0.1.0'
+
+depends 'apt', '~> 4.0.1'
+depends 'apache2', '~> 3.2.2'
+depends 'php', '~> 1.2.4'
+depends 'php-mcrypt', '~> 1.0.0'
+depends 'mysql', '~> 7.0.0'
+depends 'mysql2_chef_gem', '~> 1.1.0'
+depends 'database', '~> 5.1.2'
+

--- a/cookbooks/foresttofarm-development/recipes/database.rb
+++ b/cookbooks/foresttofarm-development/recipes/database.rb
@@ -1,0 +1,67 @@
+#
+# Cookbook Name:: development
+# Recipe:: database
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+
+# Install and configure the MySQL client.
+mysql_client 'default' do
+    action :create
+end
+
+# Install and configure the MySQL service.
+mysql_service 'default' do
+    initial_root_password node['foresttofarm.org']['database']['root_password']
+    action [:create,:start]
+end
+
+# Install the mysql2_chef_gem which is required by the mysql_database cookbook.
+mysql2_chef_gem 'default' do
+    action :install
+end
+
+# Let's hang on to the connection info so we don't have to repeat it.  It's
+# pretty verbose.
+connection_info = {
+    :host => node['foresttofarm.org']['database']['host'],
+    :username => 'root',
+    :password => node['foresttofarm.org']['database']['root_password']
+}
+
+# create the database instance
+mysql_database node['foresttofarm.org']['database']['name'] do
+    connection connection_info
+    action :create
+end
+
+# Add a database user
+mysql_database_user node['foresttofarm.org']['database']['username'] do
+    connection connection_info
+    password node['foresttofarm.org']['database']['password']
+    database_name node['foresttofarm.org']['database']['name']
+    host node['foresttofarm.org']['database']['host']
+    action [:create,:grant]
+end
+
+# Import the database's schema file from the data directory
+
+schema_path = File.join(node['foresttofarm.org']['database']['data_directory'], node['foresttofarm.org']['database']['schema_file'])
+
+# Cache some of the attributes we need to keep this marginally readable.
+host = node['foresttofarm.org']['database']['host']
+username = node['foresttofarm.org']['database']['username']
+password = node['foresttofarm.org']['database']['password']
+database_name = node['foresttofarm.org']['database']['name']
+
+execute "Import database schema" do
+  command "mysql -h #{host} -u #{username} -p#{password} -D #{database_name} < #{schema_path}"
+  not_if  "mysql -h #{host} -u #{username} -p#{password} -D #{database_name} -e 'describe plants;'"
+end
+
+# Import the data into the newly created database from the csv file.
+data_file_path = File.join(node['foresttofarm.org']['database']['data_directory'], node['foresttofarm.org']['database']['data_file'])
+execute "Import data into schema" do
+    cwd node['foresttofarm.org']['source_directory']
+    command "php artisan data:load #{data_file_path}"
+end

--- a/cookbooks/foresttofarm-development/recipes/default.rb
+++ b/cookbooks/foresttofarm-development/recipes/default.rb
@@ -1,0 +1,15 @@
+#
+# Cookbook Name:: foresttofarm-development
+# Recipe:: default
+#
+# Copyright (c) 2016 Daniel Bingham, All Rights Reserved.
+
+include_recipe  'apt::default'
+include_recipe  'apache2::default'
+include_recipe  'php::default'
+include_recipe  'php::module_mysql'
+include_recipe  'php-mcrypt::default'
+include_recipe  'apache2::mod_php5'
+include_recipe  'foresttofarm-development::php'
+include_recipe  'foresttofarm-development::web'
+include_recipe  'foresttofarm-development::database'

--- a/cookbooks/foresttofarm-development/recipes/php.rb
+++ b/cookbooks/foresttofarm-development/recipes/php.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook Name:: development
+# Recipe:: php
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+
+
+# There's a bug in the PHP Cookbook that makes it impossible to
+# edit apache2's PHP configuration file through that cookbook.  So
+# to work around this, we're going to use Chef's FileEdit object in
+# a Ruby Block.
+#
+# Bug reference: https://github.com/chef-cookbooks/php/issues/116 
+ruby_block 'Update the PHP Apache2 Configuration' do
+    block do
+        php_ini_handle = Chef::Util::FileEdit.new(node['foresttofarm.org']['php']['config_file_path'])
+        php_ini_handle.search_file_replace_line(/display_errors = Off/, 'display_errors = On');
+        php_ini_handle.search_file_replace_line(/display_startup_errors = Off/, 'display_startup_errors = On');
+        php_ini_handle.search_file_replace_line(/error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT/, 'error_reporting = E_ALL');
+        php_ini_handle.write_file
+    end
+end
+
+# This is something that really ought to have been handled by the
+# php5-mcrypt cookbook, but wasn't.  So... we're doing it here!
+execute "Enable mcrypt mod" do
+    command "php5enmod mcrypt"
+end

--- a/cookbooks/foresttofarm-development/recipes/web.rb
+++ b/cookbooks/foresttofarm-development/recipes/web.rb
@@ -1,0 +1,14 @@
+#
+# Cookbook Name:: development
+# Recipe:: web
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+    
+# Create the virtual host configuration file.
+web_app node['foresttofarm.org']['site_name'] do
+    server_name node['foresttofarm.org']['server_name']
+    server_aliases [node['fqdn']] + node['foresttofarm.org']['server_aliases']
+    docroot node['foresttofarm.org']['document_root'] 
+    cookbook 'apache2' 
+end

--- a/cookbooks/foresttofarm-development/spec/spec_helper.rb
+++ b/cookbooks/foresttofarm-development/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'chefspec'
+require 'chefspec/berkshelf'

--- a/cookbooks/foresttofarm-development/spec/unit/recipes/database_spec.rb
+++ b/cookbooks/foresttofarm-development/spec/unit/recipes/database_spec.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: development
+# Spec:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'development::database' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/cookbooks/foresttofarm-development/spec/unit/recipes/default_spec.rb
+++ b/cookbooks/foresttofarm-development/spec/unit/recipes/default_spec.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: development
+# Spec:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'development::default' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/cookbooks/foresttofarm-development/spec/unit/recipes/php_spec.rb
+++ b/cookbooks/foresttofarm-development/spec/unit/recipes/php_spec.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: development
+# Spec:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'development::php' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/cookbooks/foresttofarm-development/spec/unit/recipes/web_spec.rb
+++ b/cookbooks/foresttofarm-development/spec/unit/recipes/web_spec.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: development
+# Spec:: default
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'development::web' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/cookbooks/foresttofarm-development/test/recipes/database.rb
+++ b/cookbooks/foresttofarm-development/test/recipes/database.rb
@@ -1,0 +1,18 @@
+# # encoding: utf-8
+
+# Inspec test for recipe development::database
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+unless os.windows?
+  describe user('root') do
+    it { should exist }
+    skip 'This is an example test, replace with your own test.'
+  end
+end
+
+describe port(80) do
+  it { should_not be_listening }
+  skip 'This is an example test, replace with your own test.'
+end

--- a/cookbooks/foresttofarm-development/test/recipes/default_test.rb
+++ b/cookbooks/foresttofarm-development/test/recipes/default_test.rb
@@ -1,0 +1,18 @@
+# # encoding: utf-8
+
+# Inspec test for recipe development::default
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+unless os.windows?
+  describe user('root') do
+    it { should exist }
+    skip 'This is an example test, replace with your own test.'
+  end
+end
+
+describe port(80) do
+  it { should_not be_listening }
+  skip 'This is an example test, replace with your own test.'
+end

--- a/cookbooks/foresttofarm-development/test/recipes/php.rb
+++ b/cookbooks/foresttofarm-development/test/recipes/php.rb
@@ -1,0 +1,18 @@
+# # encoding: utf-8
+
+# Inspec test for recipe development::php
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+unless os.windows?
+  describe user('root') do
+    it { should exist }
+    skip 'This is an example test, replace with your own test.'
+  end
+end
+
+describe port(80) do
+  it { should_not be_listening }
+  skip 'This is an example test, replace with your own test.'
+end

--- a/cookbooks/foresttofarm-development/test/recipes/web.rb
+++ b/cookbooks/foresttofarm-development/test/recipes/web.rb
@@ -1,0 +1,18 @@
+# # encoding: utf-8
+
+# Inspec test for recipe development::web
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+unless os.windows?
+  describe user('root') do
+    it { should exist }
+    skip 'This is an example test, replace with your own test.'
+  end
+end
+
+describe port(80) do
+  it { should_not be_listening }
+  skip 'This is an example test, replace with your own test.'
+end

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,50 @@
 # Forest to Farm
 
-A database website storing and indexing data on useful or edit plants that can
-be used in a forest gardening or permaculture context.
+Forest to Farm is an online, open source database of useful plants based on
+data assembled by Eric Toesenmeier and Dave Jacke in Edible Forest Gardens 
+Vol. 2.  It is intended to help permaculturists, agro-ecologists, and home
+gardeners in assembling permaculture systems and practicing restoration
+agriculture. 
+
+The current version of Forest to Farm may be used here at
+[foresttofarm.org](http://foresttofarm.org).
+
+## Helping Out
+
+Forest to Farm is an open source project and we appreciate any help offered. If
+you'd like to help develop it, take a look at the code standards document, and
+then spend a little time reading through the issues and milestones to get a
+feeling for where your efforts would be best spent.  
+
+## Setting Up a Development Environment 
+
+The source includes a vagrant file and chef code to provision a full
+development vm.  To use it, you'll need to download and install
+[Vagrant](https://www.vagrantup.com/), the Vagrant
+[Berkshelf](http://berkshelf.com/) plugin, and the [Chef
+DK](https://www.chef.io/). Please see the Vagrant, Berkshelf, and Chef websites
+for installation instructions. 
+
+Once you have vagrant and vagrant-berkshelf installed, you can just 
+type ``vagrant up`` in the repository directory (the same one as the vagrant file
+and this README) to bring up your development vm.  
+
+The vm is configured to have a static private ip on your local network
+(192.168.34.34).  To view your development version of Forest to Farm in a web
+browser edit your hosts file and add a line to point ``foresttofarm.local`` to 
+this ip address.
+
+```
+192.168.34.34   foresttofarm.local
+```
+
+You can now develop code locally in your favorite editor or IDE and test it
+using your vagrant vm.  The code will be shared with the vm from your local
+machine through the magic of vagrant shared folders.
+
+You're now ready to hack away on Forest to Farm.
+
+## Code Documentation
+
+TODO
 

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,12 @@ feeling for where your efforts would be best spent.
 
 ## Setting Up a Development Environment 
 
+The first thing you'll need to do after cloning the repository is 
+run ``composer install`` in the repository directory in order to install
+Laravel's dependencies.  You may need to install composer and PHP on your
+machine in order to do so.  Please see [Composer's
+website](https://getcomposer.org/) for download and installation instructions.
+
 The source includes a vagrant file and chef code to provision a full
 development vm.  To use it, you'll need to download and install
 [Vagrant](https://www.vagrantup.com/), the Vagrant
@@ -42,9 +48,18 @@ You can now develop code locally in your favorite editor or IDE and test it
 using your vagrant vm.  The code will be shared with the vm from your local
 machine through the magic of vagrant shared folders.
 
+
 You're now ready to hack away on Forest to Farm.
 
 ## Code Documentation
+
+TODO
+
+## Testing
+
+TODO
+
+## Building
 
 TODO
 


### PR DESCRIPTION
Use Vagrant, with chef for provisioning, to create local development virtual environments.
