### PR TITLE
Working Around a Bug in PhantomJS that halts Vagrant Provisioning

### DIFF
--- a/cookbooks/foresttofarm-development/recipes/grunt.rb
+++ b/cookbooks/foresttofarm-development/recipes/grunt.rb
@@ -7,6 +7,8 @@
 # Install grunt client
 nodejs_npm "grunt-cli"
 
+apt_package "phantomjs"
+
 # We need to run npm install in order to install all of grunt's dependencies.
 # Should pick up in project.json with out any help.
 execute "Run 'npm install' in the project directory" do

--- a/cookbooks/foresttofarm-development/recipes/grunt.rb
+++ b/cookbooks/foresttofarm-development/recipes/grunt.rb
@@ -7,8 +7,6 @@
 # Install grunt client
 nodejs_npm "grunt-cli"
 
-apt_package "phantomjs"
-
 # We need to run npm install in order to install all of grunt's dependencies.
 # Should pick up in project.json with out any help.
 execute "Run 'npm install' in the project directory" do

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-contrib-jasmine": "^1.0.3",
+    "grunt-contrib-jasmine": "^0.9.0",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-phpunit-runner": "^0.1.9",
     "grunt-template-jasmine-requirejs": "^0.2.3"


### PR DESCRIPTION
There's a bug in phantomjs's node installer that causes vagrant provisioning to halt and crash from a clean installation.  It appears to be related to the version of phantomjs (2.1.12), which is required by grunt-contrib-jasmine.  To work around it, we need to either install phantomjs by some other method (apt install 1.9.0-1) or we need to install a different version of grunt-contrib-jasmine that pulls a non-broken version of phantomjs.  
